### PR TITLE
fix participants fetching invitations; closes #28

### DIFF
--- a/application/handlers.go
+++ b/application/handlers.go
@@ -586,11 +586,6 @@ func applicationInvitationsListHandler(c *gin.Context) {
 		return
 	}
 
-	if userID != nil && *userID != app.UserID {
-		provide.RenderError("forbidden", 403, c)
-		return
-	}
-
 	invitations := app.pendingInvitations() // FIXME-- paginate the in-memory invitations list within redis
 	invitedUsers := make([]*user.User, 0)
 	for _, invite := range invitations {


### PR DESCRIPTION
currently when a workgroup participant attempts to fetch application invitations, a `403 forbidden` is returned. This is fixed by removing the `userID` constraint from `applicationInvitationsListHandler`